### PR TITLE
Improved force add

### DIFF
--- a/deltabot/deltabot.py
+++ b/deltabot/deltabot.py
@@ -225,11 +225,16 @@ class DeltaBot(object):
     def already_replied(self, comment):
         """ Returns true if Deltabot has replied to this comment """
         comment = self.reddit.get_submission(comment.permalink).comments[0]
+        message = self.get_message('confirmation')
         for reply in comment.replies:
             author = str(reply.author).lower()
             me = self.config.account['username'].lower()
             if author == me:
-                return True;
+                if str(message)[0:15] in str(reply):
+                    return True
+                else:
+                    reply.delete()
+                    return False                 
         return False
 
 


### PR DESCRIPTION
Force add now works even if deltabot has already replied. It will not
give a delta if it's already confirmed one, but it will remove any other
comments and re-add them. There is a way to edit instead of delete/add,
but I couldn't get it to work. This should be improved in the future for
aesthetic purposes.

This code assumes that the confirmation message always starts with the
same first 15 characters.
