### PR TITLE
Update deltabot.py

### DIFF
--- a/deltabot/deltabot.py
+++ b/deltabot/deltabot.py
@@ -259,7 +259,7 @@ class DeltaBot(object):
         awardee = parent.author
         while not comment.is_root:
             comment = self.reddit.get_info(thing_id=comment.parent_id)
-            parent = self.reddit.get_info(thing_id=comment.parent_id)
+            parent = self.reddit.get_info(thing_id=parent.parent_id)
 
             if (comment.author == awarder
                 and parent.author == awardee


### PR DESCRIPTION
points_already_awarded_to_ancestor was comparing the parent of the current comment's id to the parent of the current's comment id.

I changed the second one to the parent of the parent's id.

It should be correct if the various functions are doing what I think it is doing.
