### PR TITLE
Initial implementation of special flair for monthly top 10 users

### DIFF
--- a/deltabot/deltabot.py
+++ b/deltabot/deltabot.py
@@ -538,6 +538,14 @@ class DeltaBot(object):
             new_css = current_css.replace(top_1_css, '').replace(top_10_css, '').strip()
             self.subreddit.set_flair(redditor,flair_css_class=new_css)
 
+        ### Remove special css classes from this month
+        ### so that changes are reflected on every update
+        for score in top_scores:
+            redditor = score['user']
+            current_css = self.subreddit.get_flair(redditor)['flair_css_class']
+            new_css = current_css.replace(top_1_css, '').replace(top_10_css, '').strip()
+            self.subreddit.set_flair(redditor,flair_css_class=new_css)
+
         ### Set special css class for top user
         top_redditor = top_scores[0]['user']
         top_1_current = self.subreddit.get_flair(top_redditor)['flair_css_class']


### PR DESCRIPTION
This is an initial implementation of the feature requested in #18

This uses the flair['top1'] and flair['top10'] values set in the config.json to add a special CSS class to the month's top earner and a different, special CSS class for the month's top 2-10 earners.

This clears last month's CSS flairs as well as this months, so that only 10 users have the special flairs at any given time.

The update_top_ten_css method only modifies the CSS class of the flair, not the actual value.

This HAS NOT BEEN TESTED. Although the tests pass, I have no real way of testing this without access to DeltaBot.
