### PR TITLE
Fixed removal of flair text when changing CSS class

### DIFF
--- a/deltabot/deltabot.py
+++ b/deltabot/deltabot.py
@@ -534,32 +534,40 @@ class DeltaBot(object):
         last_month_scores = self.get_top_ten_scores_for_date(last_month)
         for score in last_month_scores:
             redditor = score['user']
-            current_css = self.subreddit.get_flair(redditor)['flair_css_class']
+            flair = self.subreddit.get_flair(redditor)
+            flair_text = flair['flair_text'] 
+            current_css = flair['flair_css_class']
             new_css = current_css.replace(top_1_css, '').replace(top_10_css, '').strip()
-            self.subreddit.set_flair(redditor,flair_css_class=new_css)
+            self.subreddit.set_flair(redditor,flair_text=flair_text,flair_css_class=new_css)
 
         ### Remove special css classes from this month
         ### so that changes are reflected on every update
         for score in top_scores:
             redditor = score['user']
-            current_css = self.subreddit.get_flair(redditor)['flair_css_class']
+            flair = self.subreddit.get_flair(redditor)
+            flair_text = flair['flair_text'] 
+            current_css = flair['flair_css_class']
             new_css = current_css.replace(top_1_css, '').replace(top_10_css, '').strip()
-            self.subreddit.set_flair(redditor,flair_css_class=new_css)
+            self.subreddit.set_flair(redditor,flair_text=flair_text,flair_css_class=new_css)
 
         ### Set special css class for top user
         top_redditor = top_scores[0]['user']
-        top_1_current = self.subreddit.get_flair(top_redditor)['flair_css_class']
+        flair = self.subreddit.get_flair(redditor)
+        flair_text = flair['flair_text'] 
+        top_1_current = flair['flair_css_class']
         if top_1_css not in top_1_current:
             new_css = '{} {}'.format(top_1_current, top_1_css)
-            self.subreddit.set_flair(top_redditor,flair_css_class=new_css)
+            self.subreddit.set_flair(top_redditor,flair_text=flair_text,flair_css_class=new_css)
 
         ### Set special css class for top 2-10 users
         for i in range(1, 10):
             redditor = top_scores[i]['user']
-            current_css = self.subreddit.get_flair(redditor)['flair_css_class']
+            flair = self.subreddit.get_flair(redditor)
+            flair_text = flair['flair_text'] 
+            current_css = flair['flair_css_class']
             if top_10_css not in current_css:
                 new_css = '{} {}'.format(current_css,top_10_css)
-                self.subreddit.set_flair(redditor,flair_css_class=new_css)
+                self.subreddit.set_flair(redditor,flair_text=flair_text,flair_css_class=new_css)
 
     def update_scoreboard(self):
         """ Update the top 10 list with highest scores. """


### PR DESCRIPTION
I misunderstood the set_flair call and was under the impression that set_flair would not remove the text if the flair_text argument was left out. I was wrong.

It now grabs the text before removing the CSS class and puts it back.
